### PR TITLE
Feature Add: Start at boot

### DIFF
--- a/background.js
+++ b/background.js
@@ -2,9 +2,11 @@ var width = 1000;
 var height = 650;
 
 chrome.storage.sync.get({
-  autoUpdate: true
+  autoUpdate: true,
+  autoStart: true
 }, function(items) {
-  autoUpdate = items.autoUpdate
+  autoUpdate = items.autoUpdate,
+  autoStart = items.autoStart
   if (autoUpdate) {
     chrome.runtime.onMessage.addListener(function requested(request) {
       if (request.method === 'resize') {
@@ -59,6 +61,13 @@ function handleWindow() {
     }
   }, 50);
 }
+
+chrome.runtime.onStartup.addListener(function() {
+  if (autoStart) {
+    restore_options();
+	handleWindow();
+  }
+});
 
 chrome.commands.onCommand.addListener( function(command) {
   restore_options();

--- a/options.html
+++ b/options.html
@@ -11,6 +11,17 @@
 <body class="container">
   <div class="row">
     <div class="column">
+	  <h5 style="margin: 0;">Open at Startup:</h5>
+	</div>
+  </div>
+  <div class="row">
+    <div class="column">
+      <input type="checkbox" id="autoStart">
+      <label class="label-inline" for="autoStart">Open at browser startup?</label>
+    </div>
+  </div>
+  <div class="row">
+    <div class="column">
       <h5 style="margin: 0;">Window Size:</h5>
     </div>
   </div>

--- a/options.js
+++ b/options.js
@@ -3,10 +3,12 @@ function save_options() {
   let width = Number(document.getElementById('width').value);
   let height = Number(document.getElementById('height').value);
   let autoUpdate = document.getElementById('autoUpdate').checked;
+  let autoStart = document.getElementById('autoStart').checked;
   chrome.storage.sync.set({
     width: width,
     height: height,
-    autoUpdate: autoUpdate
+    autoUpdate: autoUpdate,
+	autoStart: autoStart
   }, function() {
     // Update status to let user know options were saved.
     var status = document.getElementById('status');
@@ -21,11 +23,13 @@ function restore_options() {
   chrome.storage.sync.get({
     width: 1000,
     height: 650,
-    autoUpdate: true
+    autoUpdate: true,
+	autoStart: true
   }, function(items) {
     document.getElementById('width').value = items.width;
     document.getElementById('height').value = items.height;
     document.getElementById('autoUpdate').checked = items.autoUpdate;
+	document.getElementById('autoStart').checked = items.autoStart;
   });
 }
 


### PR DESCRIPTION
Added listener to load the messages window on Chrome boot (to replicate an option that used to be found in the Hangouts app). Added option to settings page and options storage to allow users to opt out of this behavior.

Tested behavior on Windows 10, Chrome 86.0.4240.183